### PR TITLE
Fixed the headlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ Converts this [hard to read stack dump](https://raw.githubusercontent.com/wiki/m
 ![Screenshot](https://raw.githubusercontent.com/wiki/maruel/panicparse/screenshot3.png "Screenshot")
 
 
-Usage
------
+Installation
+------------
 
     go get github.com/maruel/panicparse
 
+
+Usage
+-----
 
 ### Piping a stack trace from another process
 


### PR DESCRIPTION
While looking for a way to use panicparse as a library, I was confused by the "Usage" headline, since I found no way to use it as a library there, only how to install the commandline utility with "go get".

Updated the headlines.