### PR TITLE
stack: use a teereader to avoid outputting with bad newlines

### DIFF
--- a/stack/stack.go
+++ b/stack/stack.go
@@ -501,7 +501,7 @@ func SortBuckets(buckets map[*Signature][]Goroutine) Buckets {
 func ParseDump(r io.Reader, out io.Writer) ([]Goroutine, error) {
 	goroutines := make([]Goroutine, 0, 16)
 	var goroutine *Goroutine
-	scanner := bufio.NewScanner(r)
+	scanner := bufio.NewScanner(io.TeeReader(r, out))
 	scanner.Split(bufio.ScanLines)
 	// TODO(maruel): Use a formal state machine. Patterns follows:
 	// - reRoutineHeader
@@ -517,9 +517,6 @@ func ParseDump(r io.Reader, out io.Writer) ([]Goroutine, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if len(line) == 0 {
-			if goroutine == nil {
-				_, _ = io.WriteString(out, line+"\n")
-			}
 			goroutine = nil
 			continue
 		}
@@ -552,7 +549,6 @@ func ParseDump(r io.Reader, out io.Writer) ([]Goroutine, error) {
 					continue
 				}
 			}
-			_, _ = io.WriteString(out, line+"\n")
 			continue
 		}
 


### PR DESCRIPTION
Right now the output looks a bit like this running it through my test suite:

```
make ...
                       some other command
                                        another command
```

This fixes that by using an `io.TeeReader`. It does however leave the panic on the screen before parsing it, I think this is kind of a feature depending on how you look at it. The output otherwise is unaffected (save the newlines).