### PR TITLE
allow matching and filtering traces

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -25,9 +25,8 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"syscall"
-
 	"regexp"
+	"syscall"
 
 	"github.com/maruel/panicparse/stack"
 	"github.com/mattn/go-colorable"
@@ -111,8 +110,8 @@ func Main() error {
 	forceColor := flag.Bool("force-color", false, "Forcibly enable coloring when with stdout is redirected")
 	parse := flag.Bool("parse", true, "Parses source files to deduct types; use -parse=false to work around bugs in source parser")
 	verboseFlag := flag.Bool("v", false, "Enables verbose logging output")
-	filterFlag := flag.String("f", "", "A regexp to only show traces that does NOT match its, ex: -f 'IO wait|syscall'")
-	matchFlag := flag.String("m", "", "A regexp to only show traces that match it, ex: -ex 'semacquire|file.go'")
+	filterFlag := flag.String("f", "", "Regexp ti filter out headers that match, ex: -f 'IO wait|syscall'")
+	matchFlag := flag.String("m", "", "Regexp to filter by only headers that match, ex: -m 'semacquire|file.go'")
 	flag.Parse()
 
 	log.SetFlags(log.Lmicroseconds)

--- a/internal/main.go
+++ b/internal/main.go
@@ -27,6 +27,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"regexp"
+
 	"github.com/maruel/panicparse/stack"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
@@ -55,7 +57,7 @@ var defaultPalette = stack.Palette{
 }
 
 // process copies stdin to stdout and processes any "panic: " line found.
-func process(in io.Reader, out io.Writer, p *stack.Palette, s stack.Similarity, fullPath, parse bool) error {
+func process(in io.Reader, out io.Writer, p *stack.Palette, s stack.Similarity, fullPath, parse bool, filter, match *regexp.Regexp) error {
 	goroutines, err := stack.ParseDump(in, out)
 	if err != nil {
 		return err
@@ -69,7 +71,16 @@ func process(in io.Reader, out io.Writer, p *stack.Palette, s stack.Similarity, 
 	buckets := stack.SortBuckets(stack.Bucketize(goroutines, s))
 	srcLen, pkgLen := stack.CalcLengths(buckets, fullPath)
 	for _, bucket := range buckets {
-		_, _ = io.WriteString(out, p.BucketHeader(&bucket, fullPath, len(buckets) > 1))
+		header := p.BucketHeader(&bucket, fullPath, len(buckets) > 1)
+		if filter != nil && filter.MatchString(header) {
+			continue
+		}
+
+		if match != nil && !match.MatchString(header) {
+			continue
+		}
+
+		_, _ = io.WriteString(out, header)
 		_, _ = io.WriteString(out, p.StackLines(&bucket.Signature, srcLen, pkgLen, fullPath))
 	}
 	return err
@@ -100,11 +111,36 @@ func Main() error {
 	forceColor := flag.Bool("force-color", false, "Forcibly enable coloring when with stdout is redirected")
 	parse := flag.Bool("parse", true, "Parses source files to deduct types; use -parse=false to work around bugs in source parser")
 	verboseFlag := flag.Bool("v", false, "Enables verbose logging output")
+	filterFlag := flag.String("f", "", "A regexp to only show traces that does NOT match its, ex: -f 'IO wait|syscall'")
+	matchFlag := flag.String("m", "", "A regexp to only show traces that match it, ex: -ex 'semacquire|file.go'")
 	flag.Parse()
 
 	log.SetFlags(log.Lmicroseconds)
 	if !*verboseFlag {
 		log.SetOutput(ioutil.Discard)
+	}
+
+	var (
+		excludeRe *regexp.Regexp
+		matchRe   *regexp.Regexp
+	)
+
+	if *filterFlag != "" {
+		var err error
+		if excludeRe, err = regexp.Compile(*filterFlag); err != nil {
+			return err
+		}
+	}
+
+	if *matchFlag != "" {
+		var err error
+		if matchRe, err = regexp.Compile(*matchFlag); err != nil {
+			return err
+		}
+	}
+
+	if excludeRe != nil && matchRe != nil {
+		return errors.New("can't specify both match and filter")
 	}
 
 	s := stack.AnyPointer
@@ -135,5 +171,5 @@ func Main() error {
 	default:
 		return errors.New("pipe from stdin or specify a single file")
 	}
-	return process(in, out, p, s, *fullPath, *parse)
+	return process(in, out, p, s, *fullPath, *parse, excludeRe, matchRe)
 }

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -6,6 +6,7 @@ package internal
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -108,6 +109,50 @@ func TestProcessNoColor(t *testing.T) {
 		"    isolate  isolate.go:148       archive(#4, #1, #2, 0x22, #3, 0xc20804666a, 0x17, 0, 0, 0, ...)",
 		"    isolate  isolate.go:102       Archive(#4, #1, #2, 0x22, #3, 0, 0)",
 		"    main     batch_archive.go:166 func·004(0x7fffc3b8f13a, 0x2c)",
+		"2: running [0~1 minutes]",
+		"    yaml.v2  yaml.go:153          handleErr(#5)",
+		"    reflect  value.go:2125        Value.assignTo(0x570860, #6, 0x15)",
+		"    main     main.go:428          main()",
+		"",
+	}
+	actual := strings.Split(out.String(), "\n")
+	for i := 0; i < len(actual) && i < len(expected); i++ {
+		ut.AssertEqualIndex(t, i, expected[i], actual[i])
+	}
+	ut.AssertEqual(t, expected, actual)
+}
+func TestProcessMatch(t *testing.T) {
+	out := &bytes.Buffer{}
+	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &stack.Palette{}, stack.AnyPointer,
+		false, false, nil, regexp.MustCompile(`batchArchiveRun`),
+	)
+	ut.AssertEqual(t, nil, err)
+	expected := []string{
+		"panic: runtime error: index out of range",
+		"",
+		"1: running [5 minutes] [locked] [Created by main.(*batchArchiveRun).main @ batch_archive.go:167]",
+		"    archiver archiver.go:325      (*archiver).PushFile(#1, 0xc20968a3c0, 0x5b, 0xc20988c280, 0x7d, 0, 0)",
+		"    isolate  isolate.go:148       archive(#4, #1, #2, 0x22, #3, 0xc20804666a, 0x17, 0, 0, 0, ...)",
+		"    isolate  isolate.go:102       Archive(#4, #1, #2, 0x22, #3, 0, 0)",
+		"    main     batch_archive.go:166 func·004(0x7fffc3b8f13a, 0x2c)",
+		"",
+	}
+	actual := strings.Split(out.String(), "\n")
+	for i := 0; i < len(actual) && i < len(expected); i++ {
+		ut.AssertEqualIndex(t, i, expected[i], actual[i])
+	}
+	ut.AssertEqual(t, expected, actual)
+}
+
+func TestProcessFilter(t *testing.T) {
+	out := &bytes.Buffer{}
+	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &stack.Palette{}, stack.AnyPointer,
+		false, false, regexp.MustCompile(`batchArchiveRun`), nil,
+	)
+	ut.AssertEqual(t, nil, err)
+	expected := []string{
+		"panic: runtime error: index out of range",
+		"",
 		"2: running [0~1 minutes]",
 		"    yaml.v2  yaml.go:153          handleErr(#5)",
 		"    reflect  value.go:2125        Value.assignTo(0x570860, #6, 0x15)",

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -48,7 +48,7 @@ var data = []string{
 
 func TestProcess(t *testing.T) {
 	out := &bytes.Buffer{}
-	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &defaultPalette, stack.AnyPointer, false, false)
+	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &defaultPalette, stack.AnyPointer, false, false, nil, nil)
 	ut.AssertEqual(t, nil, err)
 	expected := []string{
 		"panic: runtime error: index out of range",
@@ -73,7 +73,7 @@ func TestProcess(t *testing.T) {
 
 func TestProcessFullPath(t *testing.T) {
 	out := &bytes.Buffer{}
-	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &defaultPalette, stack.AnyValue, true, false)
+	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &defaultPalette, stack.AnyValue, true, false, nil, nil)
 	ut.AssertEqual(t, nil, err)
 	expected := []string{
 		"panic: runtime error: index out of range",
@@ -98,7 +98,7 @@ func TestProcessFullPath(t *testing.T) {
 
 func TestProcessNoColor(t *testing.T) {
 	out := &bytes.Buffer{}
-	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &stack.Palette{}, stack.AnyPointer, false, false)
+	err := process(bytes.NewBufferString(strings.Join(data, "\n")), out, &stack.Palette{}, stack.AnyPointer, false, false, nil, nil)
 	ut.AssertEqual(t, nil, err)
 	expected := []string{
 		"panic: runtime error: index out of range",


### PR DESCRIPTION
This PR adds 2 new flags:
```
-f `regexp`, hides trace headers that matches the regexp.
-m `regexp`, shows only the trace headers that matches the regexp.
```

Example:

```
➤ go run main.go -m 'PutTask|RemoveTask' ../../xxx/xxx/crash.log
1: semacquire [26 minutes] [Created by reportQueue.PutTask @ q.go:104]
    sync          sema.go:297                 runtime_notifyListWait(#343, #735)
    sync          cond.go:57                  (*Cond).Wait(#342)
    io            pipe.go:47                  (*pipe).read(#341, #348, 0x8000, 0x8000, 0, 0, 0)
    io            pipe.go:130                 (*PipeReader).Read(#588, #348, 0x8000, 0x8000, 0x8000, 0x8000, #13)
    io            io.go:390                   copyBuffer(#1482, #1125, #7, #588, #348, 0x8000, 0x8000, #1482, 0x4a80ac, 0x25)
    io            io.go:360                   Copy(#1482, #1125, #7, #588, 0xbdc020, 0, #1482)
    iodb          bucket.go:206               (*bucket).PutTimed.func1(#1482, #1125, #1125, #1482)
    iodb          bucket.go:167               (*bucket).PutTimedFunc(#62, #298, 0x20, #1124, #1383, 0, 0, 0, 0, 0)
    iodb          bucket.go:207               (*bucket).PutTimed(#62, #298, 0x20, #7, #588, #1383, 0, 0, 0, 0xa15711, ...)
    reportQueue   q.go:99                     PutTask.func1(#437, #1383, #395, 0x4, #1193, #303, #44)

```