### PR TITLE
webstack.PanicToHTML: Parse from an io.Reader and write to io.Writer

### DIFF
--- a/stack/webstack/webstack_test.go
+++ b/stack/webstack/webstack_test.go
@@ -5,8 +5,10 @@
 package webstack
 
 import (
+	"bytes"
 	"context"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -131,3 +133,18 @@ func BenchmarkSnapshotHandle(b *testing.B) {
 func dummy(ctx context.Context, a1, a2, a3, a4, a5, a6, a7, a8, a9 *int) {
 	<-ctx.Done()
 }
+
+func TestPanicToHTML(t *testing.T) {
+	buf := &bytes.Buffer{}
+	err := PanicToHTML(strings.NewReader(singlePanic), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("example.go")) {
+		t.Error("Output should contain the source file name")
+	}
+}
+
+const singlePanic = `goroutine 182 [semacquire]:
+main.b2(0xc000192068)
+  /example/example.go:86 +0x66`


### PR DESCRIPTION
This public function allows others to embed panicparse as a library.

I made a very terrible web version of panicparse, running as a standalone container on Google Cloud Run: https://combinestacks.evanjones.ca/  . To do this, I needed to fork the code since all the functions I wanted to call are in the `internal` package. This makes the one function I needed public, as part of the `webstack` package since it is related?

This is probably not exactly what you want, so feel free to reject this. However, I think this would let me unfork panicparse, and just use it as a go module for my hacky tool. See the source code: https://github.com/evanj/combinestacks

(And thanks for panicparse!)