### PR TITLE
terminal: handle ctrl+c

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,13 +11,25 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/maruel/panicparse/v2/internal"
 )
 
 func main() {
+	SetupCloseHandler()
 	if err := internal.Main(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed: %s\n", err)
 		os.Exit(1)
 	}
+}
+
+func SetupCloseHandler() {
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		os.Exit(0)
+	}()
 }


### PR DESCRIPTION
control + C should terminate a text-stream handler like this.
Check out how cat, awk, sed and every other program in this category behaves.
Thanks.