### PR TITLE
Fix misuse of unbuffered os.Signal channel as argument to signal.Notify

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -281,8 +281,8 @@ func Main() error {
 	case 0:
 		in = os.Stdin
 		// Explicitly silence SIGQUIT, as it is useful to gather the stack dump
-		// from the piped command..
-		signals := make(chan os.Signal)
+		// from the piped command.
+		signals := make(chan os.Signal, 1)
 		go func() {
 			for {
 				<-signals


### PR DESCRIPTION
This addresses a new vet warning added in Go 1.17.

See https://golang.org/doc/go1.17#vet.