### PR TITLE
Add //go:build lines

### DIFF
--- a/cmd/panic/main_no_race.go
+++ b/cmd/panic/main_no_race.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build !race
 // +build !race
 
 package main

--- a/cmd/panic/main_race.go
+++ b/cmd/panic/main_race.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package main

--- a/cmd/panicweb/main_others.go
+++ b/cmd/panicweb/main_others.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build !aix && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
 // +build !aix,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows
 
 package main

--- a/cmd/panicweb/main_unix.go
+++ b/cmd/panicweb/main_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build aix || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix dragonfly freebsd linux netbsd openbsd solaris
 
 package main

--- a/cmd/panicweb/main_windows.go
+++ b/cmd/panicweb/main_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package main

--- a/internal/go1.13.go
+++ b/internal/go1.13.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.13
 // +build go1.13
 
 package internal

--- a/internal/go1.6.go
+++ b/internal/go1.6.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.6
 // +build go1.6
 
 package internal

--- a/internal/go1.9_test.go
+++ b/internal/go1.9_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.9
 // +build go1.9
 
 package internal

--- a/internal/gopre1.13.go
+++ b/internal/gopre1.13.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// +build go1.1
-// +build !go1.13
+//go:build go1.1 && !go1.13
+// +build go1.1,!go1.13
 
 package internal
 

--- a/internal/gopre1.6.go
+++ b/internal/gopre1.6.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// +build go1.1
-// +build !go1.6
+//go:build go1.1 && !go1.6
+// +build go1.1,!go1.6
 
 package internal
 

--- a/internal/gopre1.9_test.go
+++ b/internal/gopre1.9_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build !go1.9
 // +build !go1.9
 
 package internal

--- a/internal/internaltest/go1.13.go
+++ b/internal/internaltest/go1.13.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.13
 // +build go1.13
 
 package internaltest

--- a/internal/internaltest/gopre1.13.go
+++ b/internal/internaltest/gopre1.13.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// +build go1.1
-// +build !go1.13
+//go:build go1.1 && !go1.13
+// +build go1.1,!go1.13
 
 package internaltest
 

--- a/stack/go1.11_test.go
+++ b/stack/go1.11_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.11
 // +build go1.11
 
 package stack

--- a/stack/go1.13.go
+++ b/stack/go1.13.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.13
 // +build go1.13
 
 package stack

--- a/stack/go1.9_test.go
+++ b/stack/go1.9_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build go1.9
 // +build go1.9
 
 package stack

--- a/stack/gopre1.11_test.go
+++ b/stack/gopre1.11_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build !go1.11
 // +build !go1.11
 
 package stack

--- a/stack/gopre1.13.go
+++ b/stack/gopre1.13.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// +build go1.1
-// +build !go1.13
+//go:build go1.1 && !go1.13
+// +build go1.1,!go1.13
 
 package stack
 

--- a/stack/gopre1.9_test.go
+++ b/stack/gopre1.9_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+//go:build !go1.9
 // +build !go1.9
 
 package stack

--- a/stack/regen.go
+++ b/stack/regen.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-//+build tools
+//go:build tools
+// +build tools
 
 package main
 


### PR DESCRIPTION
Necessary for a clean gofmt with Go 1.17.

See https://golang.org/doc/go1.17#gofmt.

This commit was the result of running `go fmt ./...`.